### PR TITLE
README: name prometheus container

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Lastly, we can run Prometheus like so. Use the unprivileged "vagrant" user accou
 podman run \
     -p 9090:9090 \
     --detach=true \
+    --name prometheus \
     -v /etc/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml \
     docker.io/prom/prometheus:latest
 ```


### PR DESCRIPTION
This makes it easier to operate on the prometheus container. It shows up as `prometheus` in `podman ps`, and users can shell into it with `podman exec`, etc.